### PR TITLE
feature-DS17-DS30-challenge-permissions-check-and-branches

### DIFF
--- a/src/main/java/matchmaker/backend/constants/ChallengeStatus.java
+++ b/src/main/java/matchmaker/backend/constants/ChallengeStatus.java
@@ -4,6 +4,6 @@ public enum ChallengeStatus {
     OPEN_VOOR_IDEEEN,
     IN_UITVOERING,
     AFGEROND,
-    GEACHRIVEERD
+    GEARCHIVEERD
 }
 

--- a/src/main/java/matchmaker/backend/constants/Perm.java
+++ b/src/main/java/matchmaker/backend/constants/Perm.java
@@ -5,9 +5,7 @@ package matchmaker.backend.constants;
  */
 public class Perm {
     public final static String CHALLENGE_READ = "CHALLENGE_READ";
-    public final static String CHALLENGE_REACT = "CHALLENGE_REACT";
     public final static String CHALLENGE_MANAGE = "CHALLENGE_MANAGE";
-    public final static String CHALLENGE_MARK_REACTION = "CHALLENGE_MARK_REACTION";
     public final static String DEPARTMENT_CREATE = "DEPARTMENT_CREATE";
     public final static String COMPANY_EDIT = "COMPANY_EDIT";
 

--- a/src/main/java/matchmaker/backend/controllers/ChallengeController.java
+++ b/src/main/java/matchmaker/backend/controllers/ChallengeController.java
@@ -3,6 +3,8 @@ package matchmaker.backend.controllers;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
+import matchmaker.backend.constants.ChallengeStatus;
+import matchmaker.backend.constants.Perm;
 import matchmaker.backend.models.*;
 import matchmaker.backend.repositories.ChallengeRepository;
 import matchmaker.backend.repositories.ImageRepository;
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -29,23 +32,46 @@ public class ChallengeController {
     }
 
     @GetMapping("/challenge/{id}")
-    public Optional<Challenge> getChallengeById(@PathVariable("id")Long id) {
-     return repository.findById(id);
+    public ResponseEntity<Challenge> getChallengeById(@PathVariable("id")Long id, @RequestAttribute("loggedInUser") User currentUser) {
+        Optional<Challenge> target = repository.findById(id);
+        if(target.isEmpty()){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+        }
+        Challenge challenge = target.get();
+        if(!challenge.canBeSeenBy(currentUser)){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(challenge);
+
     }
 
     //Discuss, {id} or update?
     @PutMapping("/challenge/update")
-    public HttpStatus updateChallenge(@RequestBody Challenge challengeToUpdate){
-        Optional<Challenge> challenge = repository.findById(challengeToUpdate.id);
-        if (challenge.isEmpty()){
+    public HttpStatus updateChallenge(@RequestBody Challenge challengeToUpdate, @RequestAttribute("loggedInUser") User currentUser){
+        Optional<Challenge> target = repository.findById(challengeToUpdate.id);
+        if (target.isEmpty()){
             return HttpStatus.EXPECTATION_FAILED;
         }
+
+        //Grab the same challenge from the database to be sure we have valid data.
+        Challenge challengeInDatabase = target.get();
+        if(!challengeInDatabase.canBeEditedBy(currentUser)){
+            return HttpStatus.UNAUTHORIZED;
+        }
+
         repository.save(challengeToUpdate);
         return HttpStatus.OK;
     }
 
     @PostMapping(path = "/challenge")
-    public Optional<Challenge> createChallenge(@RequestBody Challenge newChallenge, @RequestAttribute("loggedInUser") User currentUser) {
+    public ResponseEntity<Challenge> createChallenge(@RequestBody Challenge newChallenge, @RequestAttribute("loggedInUser") User currentUser) {
+        if(!currentUser.isInCompany()){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+        if(!currentUser.hasPermissionAtCompany(Perm.CHALLENGE_MANAGE, currentUser.role.company.id)){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+
         Challenge checkedChallenge = new Challenge();
 
         //Only copy values we trust from the enduser. If user passes id, it is ignored.
@@ -55,7 +81,13 @@ public class ChallengeController {
         checkedChallenge.bannerImageId = newChallenge.bannerImageId;
         checkedChallenge.concludingRemarks = newChallenge.concludingRemarks;
         checkedChallenge.summary = newChallenge.summary;
-        checkedChallenge.status = newChallenge.status;
+        if(newChallenge.status == null){
+            newChallenge.status = ChallengeStatus.OPEN_VOOR_IDEEEN;
+        }
+        else{
+            checkedChallenge.status = newChallenge.status;
+
+        }
         checkedChallenge.endDate = newChallenge.endDate;
         checkedChallenge.tags = newChallenge.tags;
         //Remove the last comma, if there is one
@@ -63,19 +95,19 @@ public class ChallengeController {
             String tags = checkedChallenge.tags;
             checkedChallenge.tags = tags.substring(0,tags.length()-1);
         }
-        checkedChallenge.branch = newChallenge.branch;
+
         checkedChallenge.visibility = newChallenge.visibility;
         checkedChallenge.imageAttachmentsIds = newChallenge.imageAttachmentsIds;
         checkedChallenge.createdAt = new Date();
 
         //Set this based on the session, so no bad input can set the author, company & department
         checkedChallenge.author = currentUser;
-        checkedChallenge.company = currentUser.company;
-        checkedChallenge.department = currentUser.department;
+        checkedChallenge.company = currentUser.role.company;
+        checkedChallenge.department = currentUser.role.department;
         checkedChallenge.createdAt = new Date();
 
         Challenge savedChallenge = repository.save(checkedChallenge);
-        return Optional.of(savedChallenge);
+        return ResponseEntity.status(HttpStatus.OK).body(savedChallenge);
     }
 
     @GetMapping("/challenge/search")

--- a/src/main/java/matchmaker/backend/models/Challenge.java
+++ b/src/main/java/matchmaker/backend/models/Challenge.java
@@ -4,11 +4,16 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import matchmaker.backend.AuthInterceptor;
 import matchmaker.backend.constants.ChallengeStatus;
 import matchmaker.backend.constants.ChallengeVisibility;
+import matchmaker.backend.constants.Perm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Table(name = "challenges")
@@ -20,6 +25,10 @@ public class Challenge {
     public Challenge(){
 
     }
+
+    @Transient
+    private static final Logger log = LoggerFactory.getLogger(Challenge.class);
+
 
     public Challenge(String title, User author){
         this.author = author;
@@ -52,12 +61,63 @@ public class Challenge {
     public Date endDate;
     public String tags;
 
-    @ManyToOne
-    public Branch branch;
-    public boolean canReact;
-
-    public Long[] imageAttachmentsIds;
+    @ElementCollection
+    public List<Long> imageAttachmentsIds;
 
     @Enumerated(EnumType.ORDINAL)
     public ChallengeVisibility visibility;
+
+
+    public boolean canBeSeenBy(User user){
+        //Opties zonder account
+        if(user.equals(null)){
+            if(this.visibility == ChallengeVisibility.PUBLIC && this.status != ChallengeStatus.GEARCHIVEERD){
+                return true;
+            }
+            return false;
+        }
+        //You need an account from here on
+
+        // Status = OPEN_VOOR_IDEEEN || AFGEROND || IN_UITVOERING
+
+        if(this.visibility == ChallengeVisibility.PUBLIC && this.status != ChallengeStatus.GEARCHIVEERD){
+            return true;
+        }
+        if(this.visibility == ChallengeVisibility.INTRANET && this.status != ChallengeStatus.GEARCHIVEERD){
+            return true; //We already know the user is logged in
+        }
+
+
+        if(!user.isInCompany()){ return false; } // If user is not in a company, abort
+        Long companyId = user.role.company.id;
+
+        if(this.company.id.equals(companyId)){ return false; } // if user is not in the same company as the challenge, abort
+        //User is part of same company as the challenge
+
+        //If archived, only managers can view the challenge
+        if(status == ChallengeStatus.GEARCHIVEERD){
+            return user.hasPermissionAtCompany(Perm.CHALLENGE_MANAGE, companyId);
+        }
+
+        if(this.visibility == ChallengeVisibility.INTERNAL){
+            return true;
+        }
+
+        if(this.visibility == ChallengeVisibility.DEPARTMENT){
+            //If the user is in the same department
+            return user.role.department.id.equals(this.department.id);
+        }
+
+        log.warn("Challenge and/or user did not fit any permission conditions, some checks are missing!");
+        return false;
+    }
+
+
+    public boolean canBeEditedBy(User user){
+        if(!user.isInCompany()) { return false; }
+        boolean userPartOfCompanyChallenge = this.company.id.equals(user.role.company.id); // is user in the same company as the challenge
+        return userPartOfCompanyChallenge && user.hasPermissionAtCompany(Perm.CHALLENGE_MANAGE, user.role.company.id);
+    }
+
+
 }

--- a/src/main/java/matchmaker/backend/models/User.java
+++ b/src/main/java/matchmaker/backend/models/User.java
@@ -37,12 +37,6 @@ public class User {
     @ManyToOne
     public Role role;
 
-    @ManyToOne
-    public Department department;
-
-    @ManyToOne
-    public Company company;
-
 
     @ManyToMany
     public List<Challenge> favorites = new java.util.ArrayList<>();
@@ -51,7 +45,7 @@ public class User {
         this.name = name;
     }
 
-    public boolean hasPermissionAtCompany(Long companyId, String m){
+    public boolean hasPermissionAtCompany(String m, Long companyId){
         if(!role.getCompany().id.equals(companyId)){
             //User is not part of the company, so he dos not have the permission
             return false;
@@ -64,7 +58,9 @@ public class User {
         }
         return false;
     }
-
+    public boolean isInCompany(){
+        return this.role != null;
+    }
 
 
     public User() {

--- a/src/main/java/matchmaker/backend/models/User.java
+++ b/src/main/java/matchmaker/backend/models/User.java
@@ -46,6 +46,7 @@ public class User {
     }
 
     public boolean hasPermissionAtCompany(String m, Long companyId){
+        if(this.role.isMatchmaker) { return true; }
         if(!role.getCompany().id.equals(companyId)){
             //User is not part of the company, so he dos not have the permission
             return false;

--- a/src/main/resources/testdata/generate_testdata.sql
+++ b/src/main/resources/testdata/generate_testdata.sql
@@ -114,4 +114,22 @@ insert into challenges (id, banner_image_id, concluding_remarks, contact_informa
 values (1, null, 'Dit zijn de mooie concluding remarks', 'Contact informatie', '2023-01-01', 'Dit is de challenge description',
         '2023-09-11', 1, 'Summary', 'prototype,website', 'Innovatie kapperszaak', 2, 1, null, 1);
 
+insert into branches(id, name)
+values(1,'Advies en consultancy'),
+      (2,'Agrosector'),
+      (3,'Bouw, installatie en infrastructuur'),
+      (4,'Cultuur en sport'),
+      (5,'Delfstoffen'),
+      (6,'Financiële dienstverlening'),
+      (7,'Gezondheidszorg en maatschappelijke dienstverlening'),
+      (8, 'Autohandel, groothandel en detailhandel'),
+       (9, 'Horeca'),
+       (10,'ICT, media en communicatie'),
+       (11,'Industrie'),
+       (12, 'Onderwijs en training'),
+       (13, 'Onroerend goed'),
+       (14, 'Persoonlijke dienstverleningen en not-for-profit'),
+       (15, 'Vervoer, post en opslag'),
+       (16, 'Water en afval'),
+       (17, 'Zakelijke dienstverlening')
 

--- a/src/main/resources/testdata/generate_testdata.sql
+++ b/src/main/resources/testdata/generate_testdata.sql
@@ -60,10 +60,10 @@ values (1, '2020-01-01', true, 'Medewerker', 1, 1),
        (5, '2020-01-05', false, 'MatchMaker', 5, 5);
 
 insert into permissions (id, code_name, description, fancy_name)
-values (1, 'CHALLENGE_READ', 'Het bekijken van een challenge', 'Challenge bekijken'),
-       (2, 'CHALLENGE_REACT', 'Het reageren op een challenge', 'Reageren op Challenge'),
-       (3, 'CHALLENGE_MANAGE', 'Het beheren van een challenge', 'Beheer challenge'),
-       (4, 'CHALLENGE_MARK_REACTION', 'Het markeren van een reactie', 'Markeer reactie'),
+values (1, 'CHALLENGE_READ', 'Het bekijken van een challenge en reacties achterlaten', 'Challenge bekijken'),
+--        (2, 'CHALLENGE_REACT', 'Het reageren op een challenge', 'Reageren op Challenge'),
+       (3, 'CHALLENGE_MANAGE', 'Het beheren van een challenge & kiezen van reacties', 'Beheer challenge'),
+--        (4, 'CHALLENGE_MARK_REACTION', 'Het markeren van een reactie', 'Markeer reactie'),
        (5, 'DEPARTMENT_CREATE', 'Het creeeren van een department', 'Creeer department'),
        (6, 'COMPANY_EDIT', 'Het bewerken van een bedrijf', 'Bewerk bedrijf'),
        (7, 'COMPANY_GRADE', 'Het goedkeuren van een bedrijfsaanvraag', 'Goedkeuren bedrijfsaanvraag');
@@ -71,47 +71,47 @@ values (1, 'CHALLENGE_READ', 'Het bekijken van een challenge', 'Challenge bekijk
 
 insert into roles_permissions (role_id, permissions_id)
 values (1,1),
-       (1,2),
+--        (1,2),
        (2,1),
-       (2,2),
+--        (2,2),
        (2,3),
-       (2,4),
+--        (2,4),
        (3,1),
-       (3,2),
+--        (3,2),
        (3,3),
-       (3,4),
+--        (3,4),
        (4,1),
-       (4,2),
+--        (4,2),
        (4,3),
-       (4,4),
+--        (4,4),
        (4,5),
        (4,6),
        (5,1),
-       (5,2),
+--        (5,2),
        (5,3),
-       (5,4),
+--        (5,4),
        (5,5),
        (5,6),
        (5,7);
 
 -- Insert test data for the User table
 INSERT INTO users (id, name, info, tags, created_at, last_seen, avatar_image_id, is_email_public,
-                   is_phone_number_public, accepted_tos_date, role_id, department_id, company_id, email, phone_number)
-VALUES (1, 'Jan Bakker', 'Info1', 'tag1,tag2', '2023-01-01', '2023-01-01', NULL, true, true, '2023-01-01', 1, 1, 1, 'jan.bakker@email.com', '0612345678'),
-       (2, 'Johan de Vries', 'Info2', 'tag3,tag4', '2023-01-02', '2023-01-02', NULL, false, false, '2023-01-02', 2, 2, 2, 'johan.de.vries@email.com', '0612345678'),
-       (3, 'Florijn Munster', 'Info3', 'tag5,tag6', '2023-01-03', '2023-01-03', NULL, true, false, '2023-01-03', 3, 3, 3, 'florijn.munster@email.com', '0612345678'),
-       (4, 'Rik Wildschut', 'Info4', 'tag7,tag8', '2023-01-04', '2023-01-04', NULL, false, true, '2023-01-04', 4, 4, 4, 'rik.wildschut@email.com','0612345678'),
-       (5, 'Luke van de Pol', 'Info5', 'tag9,tag10', '2023-01-05', '2023-01-05', NULL, true, false, '2023-01-05', 5, 5, 5, 'luke.van.de.pol@email.com', '0612345678'),
-       (6, 'Eelco Jansma', 'Info6', 'tag11,tag12', '2023-01-06', '2023-01-06', NULL, true, true, '2023-01-06', 1, 6, 6, 'eelco.jansma@email.com','0612345678'),
-       (7, 'Jelle Blaeser', 'Info7', 'tag13,tag14', '2023-01-07', '2023-01-07', NULL, false, false, '2023-01-07', 2, 7, 7, 'jelle.blaeser@email.com', '0612345678'),
-       (8, 'Tjerk Venema', 'Info8', 'tag15,tag16', '2023-01-08', '2023-01-08', NULL, true, true, '2023-01-08', 3, 8, 8, 'tjerk.venema@email.com','0612345678'),
-       (9, 'Anniek de Boer', 'Info9', 'tag17,tag18', '2023-01-09', '2023-01-09', NULL, false, true, '2023-01-09', 4, 9, 9,'anniek.de.boer@email.com','0612345678'),
-       (10, 'Piet de Wit', 'Info10', 'tag19,tag20', '2023-01-10', '2023-01-10', NULL, true, false, '2023-01-10', 5, 10, 10, 'piet.de.wit@email.com','0612345678');
+                   is_phone_number_public, accepted_tos_date, role_id, email, phone_number)
+VALUES (1, 'Jan Bakker', 'Info1', 'tag1,tag2', '2023-01-01', '2023-01-01', NULL, true, true, '2023-01-01', 1,  'jan.bakker@email.com', '0612345678'),
+       (2, 'Johan de Vries', 'Info2', 'tag3,tag4', '2023-01-02', '2023-01-02', NULL, false, false, '2023-01-02', 2, 'johan.de.vries@email.com', '0612345678'),
+       (3, 'Florijn Munster', 'Info3', 'tag5,tag6', '2023-01-03', '2023-01-03', NULL, true, false, '2023-01-03', 3, 'florijn.munster@email.com', '0612345678'),
+       (4, 'Rik Wildschut', 'Info4', 'tag7,tag8', '2023-01-04', '2023-01-04', NULL, false, true, '2023-01-04', 4, 'rik.wildschut@email.com','0612345678'),
+       (5, 'Luke van de Pol', 'Info5', 'tag9,tag10', '2023-01-05', '2023-01-05', NULL, true, false, '2023-01-05', 5, 'luke.van.de.pol@email.com', '0612345678'),
+       (6, 'Eelco Jansma', 'Info6', 'tag11,tag12', '2023-01-06', '2023-01-06', NULL, true, true, '2023-01-06', 1, 'eelco.jansma@email.com','0612345678'),
+       (7, 'Jelle Blaeser', 'Info7', 'tag13,tag14', '2023-01-07', '2023-01-07', NULL, false, false, '2023-01-07', 2, 'jelle.blaeser@email.com', '0612345678'),
+       (8, 'Tjerk Venema', 'Info8', 'tag15,tag16', '2023-01-08', '2023-01-08', NULL, true, true, '2023-01-08', 3, 'tjerk.venema@email.com','0612345678'),
+       (9, 'Anniek de Boer', 'Info9', 'tag17,tag18', '2023-01-09', '2023-01-09', NULL, false, true, '2023-01-09', 4, 'anniek.de.boer@email.com','0612345678'),
+       (10, 'Piet de Wit', 'Info10', 'tag19,tag20', '2023-01-10', '2023-01-10', NULL, true, false, '2023-01-10', 5, 'piet.de.wit@email.com','0612345678');
 
-insert into challenges (id, banner_image_id, can_react, concluding_remarks, contact_information, created_at,
-                        description, end_date, status, summary, tags, title, visibility, author_id, branch_id,
+insert into challenges (id, banner_image_id, concluding_remarks, contact_information, created_at,
+                        description, end_date, status, summary, tags, title, visibility, author_id,
                         company_id, department_id)
-values (1, null, true, 'Dit zijn de mooie concluding remarks', 'Contact informatie', '2023-01-01', 'Dit is de challenge description',
-        '2023-09-11', 1, 'Summary', 'prototype,website', 'Innovatie kapperszaak', 2, 1, null, 1, 1);
+values (1, null, 'Dit zijn de mooie concluding remarks', 'Contact informatie', '2023-01-01', 'Dit is de challenge description',
+        '2023-09-11', 1, 'Summary', 'prototype,website', 'Innovatie kapperszaak', 2, 1, null, 1);
 
 


### PR DESCRIPTION
Added permissions on the challenge endpoints, except for the search endpoint.
also removed some unused fields in the permission, user object and challenge object

all permissions are overriden if the user#role#ismatchmaker (which is true for user 1)